### PR TITLE
Include config directory in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN npm install && \
     npm run build && \
     mkdir ./builder && \
     mv ./build ./builder/build && \
+    mv ./config ./builder/config && \
     mv ./tsconfig.json ./builder/tsconfig.json && \
     mv ./package.json ./builder/package.json
 


### PR DESCRIPTION
This PR fixes the missing config directory in docker builds.

### 🚒 Technical Solution
[How did you fix this bug?]
- [ ] copy the config directory during the docker build
